### PR TITLE
Use Lapack routines with explicit interface

### DIFF
--- a/src/stiff3_linalg.f90
+++ b/src/stiff3_linalg.f90
@@ -8,119 +8,200 @@ module stiff3_linalg
 
   public :: lu, back
 
-  !   !> Program for decomposing a matrix A to a lower and an upper
-  !   !> triangular form $ A = LU$.
-  !   subroutine lu(n,ipiv,a)
-  !     import dp
-  !     integer, intent(in) :: n
-  !       !! Size of the matrix
-  !     integer, intent(out) :: ipiv(n)
-  !       !! Pivot array
-  !     real(dp), intent(inout) :: a(n,n)
-  !       !! On input a matrix, on output the LU factored matrices
-  !   end subroutine
+  !> Program for decomposing a matrix A to a lower and an upper
+  !> triangular form $ A = LU$.
   interface lu
     module procedure lu_sp, lu_dp
   end interface
 
 
-  !   !> Back substitution algorithm for solution to $LUx = b$.
-  !   !> Used together with procedure `lu`, to calculate the solution
-  !   !> of a system of linear equations
-  !   subroutine back(n,ipiv,a,b)
-  !     import dp
-  !     integer, intent(in) :: n
-  !       !! Size of the linear system of equations
-  !     integer, intent(in) :: ipiv(n)
-  !       !! Pivot array
-  !     real(dp), intent(in) :: a(n,n)
-  !       !! LU-factored form of the original matrix A
-  !     real(dp), intent(inout) :: b(n)
-  !       !! On input contains the right-hand side of a system of
-  !       !! equations Ax = b, on output contains the solution vector x
-  !   end subroutine
+  !> Back substitution algorithm for solution to $LUx = b$.
+  !> Used together with procedure `lu`, to calculate the solution
+  !> of a system of linear equations
   interface back
-    module procedure back_sp, back_dp
+    module procedure back_sp, back_dp, back1_sp, back1_dp
   end interface
 
   integer, parameter :: sp = kind(1.0e0)
   integer, parameter :: dp = kind(1.0d0)
 
+  interface lapack_getrf
+    pure subroutine sgetrf(m,n,a,lda,ipiv,info)
+      import :: sp
+      real(sp), intent(inout) :: a(lda,*)
+      integer, intent(out) :: ipiv(*)
+      integer, intent(out) :: info
+      integer, intent(in) :: m
+      integer, intent(in) :: n
+      integer, intent(in) :: lda
+    end subroutine sgetrf
+    pure subroutine dgetrf(m,n,a,lda,ipiv,info)
+      import :: dp
+      real(dp), intent(inout) :: a(lda,*)
+      integer, intent(out) :: ipiv(*)
+      integer, intent(out) :: info
+      integer, intent(in) :: m
+      integer, intent(in) :: n
+      integer, intent(in) :: lda
+    end subroutine dgetrf
+  end interface lapack_getrf
+
+  interface lapack_getrs
+    pure subroutine sgetrs(trans,n,nrhs,a,lda,ipiv,b,ldb,info)
+      import :: sp
+      real(sp), intent(in) :: a(lda,*)
+      integer, intent(in) :: ipiv(*)
+      real(sp), intent(inout) :: b(ldb,*)
+      character(len=1), intent(in) :: trans
+      integer, intent(out) :: info
+      integer, intent(in) :: n
+      integer, intent(in) :: nrhs
+      integer, intent(in) :: lda
+      integer, intent(in) :: ldb
+    end subroutine sgetrs
+    pure subroutine dgetrs(trans,n,nrhs,a,lda,ipiv,b,ldb,info)
+      import :: dp
+      real(dp), intent(in) :: a(lda,*)
+      integer, intent(in) :: ipiv(*)
+      real(dp), intent(inout) :: b(ldb,*)
+      character(len=1), intent(in) :: trans
+      integer, intent(out) :: info
+      integer, intent(in) :: n
+      integer, intent(in) :: nrhs
+      integer, intent(in) :: lda
+      integer, intent(in) :: ldb
+    end subroutine dgetrs
+  end interface lapack_getrs
+
 contains
 
-  subroutine lu_sp(n,ipiv,a)
-    integer, intent(in) :: n
-    integer, intent(out) :: ipiv(n)
-    real(sp), intent(inout) :: a(n,n)
+  subroutine lu_sp(amat,ipiv,info)
+    real(sp), intent(inout) :: amat(:,:)
+      !! On input a matrix, on output the LU factored matrices
+    integer, intent(out) :: ipiv(:)
+      !! Pivot array
+    integer, intent(out), optional :: info
+      !! Exit status
+    integer :: m, n, lda, stat
+    lda = max(1,size(amat,1))
+    m = size(amat,1)
+    n = size(amat,2)
+    call lapack_getrf(m,n,amat,lda,ipiv,stat)
+    call handle_error(info,stat,"getrf")
+  end subroutine lu_sp
 
-    integer :: lda, info
-    external :: dgetrf
+  subroutine lu_dp(amat,ipiv,info)
+    real(dp), intent(inout) :: amat(:,:)
+      !! LU-factored form of the original matrix A
+    integer, intent(out) :: ipiv(:)
+      !! Pivot array
+    integer, intent(out), optional :: info
+      !! Exit status
+    integer :: m, n, lda, stat
+    lda = max(1,size(amat,1))
+    m = size(amat,1)
+    n = size(amat,2)
+    call lapack_getrf(m,n,amat,lda,ipiv,stat)
+    call handle_error(info,stat,"getrf")
+  end subroutine lu_dp
 
-    lda = n
+  subroutine back1_sp(amat,bvec,ipiv,info,trans)
+    real(sp), intent(in) :: amat(:,:)
+      !! LU-factored form of the original matrix A
+    real(sp), intent(inout), target :: bvec(:)
+      !! On input contains the right-hand side of a system of
+      !! equations Ax = b, on output contains the solution vector x
+    integer, intent(in) :: ipiv(:)
+      !! Pivot array
+    integer, intent(out), optional :: info
+      !! Exit status
+    character(len=1), intent(in), optional :: trans
 
-    call sgetrf(n,n,a,lda,ipiv,info)
+    real(sp), pointer :: bptr(:,:)
 
-    if (info /= 0) then
-      print *, "[dgetrf] info = ", info
+    bptr(1:size(bvec),1:1) => bvec
+    call back(amat,bptr,ipiv,info,trans)
+  end subroutine back1_sp
+
+  subroutine back_sp(amat,bmat,ipiv,info,trans)
+    real(sp), intent(in) :: amat(:,:)
+      !! LU-factored form of the original matrix A
+    real(sp), intent(inout) :: bmat(:,:)
+      !! On input contains the right-hand side of a system of
+      !! equations Ax = b, on output contains the solution vector x
+    integer, intent(in) :: ipiv(:)
+      !! Pivot array
+    integer, intent(out), optional :: info
+      !! Exit status
+    character(len=1), intent(in), optional :: trans
+    character(len=1) :: tra
+    integer :: n, nrhs, lda, ldb, stat
+    if (present(trans)) then
+      tra = trans
+    else
+      tra = 'n'
     end if
+    lda = max(1,size(amat,1))
+    ldb = max(1,size(bmat,1))
+    n = size(amat,2)
+    nrhs = size(bmat,2)
+    call lapack_getrs(tra,n,nrhs,amat,lda,ipiv,bmat,ldb,stat)
+    call handle_error(info,stat,"getrs")
+  end subroutine back_sp
 
-  end subroutine
-  subroutine lu_dp(n,ipiv,a)
-    integer, intent(in) :: n
-    integer, intent(out) :: ipiv(n)
-    real(dp), intent(inout) :: a(n,n)
+  subroutine back1_dp(amat,bvec,ipiv,info,trans)
+    real(dp), intent(in) :: amat(:,:)
+      !! LU-factored form of the original matrix A
+    real(dp), intent(inout), target :: bvec(:)
+      !! On input contains the right-hand side of a system of
+      !! equations Ax = b, on output contains the solution vector x
+    integer, intent(in) :: ipiv(:)
+      !! Pivot array
+    integer, intent(out), optional :: info
+      !! Exit status
+    character(len=1), intent(in), optional :: trans
 
-    integer :: lda, info
-    external :: dgetrf
+    real(dp), pointer :: bptr(:,:)
 
-    lda = n
+    bptr(1:size(bvec),1:1) => bvec
+    call back(amat,bptr,ipiv,info,trans)
+  end subroutine back1_dp
 
-    call dgetrf(n,n,a,lda,ipiv,info)
-
-    if (info /= 0) then
-      print *, "[dgetrf] info = ", info
+  subroutine back_dp(amat,bmat,ipiv,info,trans)
+    real(dp), intent(in) :: amat(:,:)
+      !! LU-factored form of the original matrix A
+    real(dp), intent(inout) :: bmat(:,:)
+      !! On input contains the right-hand side of a system of
+      !! equations Ax = b, on output contains the solution vector x
+    integer, intent(in) :: ipiv(:)
+      !! Pivot array
+    integer, intent(out), optional :: info
+    character(len=1), intent(in), optional :: trans
+    character(len=1) :: tra
+    integer :: n, nrhs, lda, ldb, stat
+    if (present(trans)) then
+      tra = trans
+    else
+      tra = 'n'
     end if
+    lda = max(1,size(amat,1))
+    ldb = max(1,size(bmat,1))
+    n = size(amat,2)
+    nrhs = size(bmat,2)
+    call lapack_getrs(tra,n,nrhs,amat,lda,ipiv,bmat,ldb,stat)
+    call handle_error(info,stat,"getrs")
+  end subroutine back_dp
 
-  end subroutine
-
-
-  subroutine back_sp(n,ipiv,a,b)
-    integer, intent(in) :: n
-    integer, intent(in) :: ipiv(n)
-    real(sp), intent(in) :: a(n,n)
-    real(sp), intent(inout) :: b(n)
-
-    integer :: lda, ldb, info
-    external :: dgetrs
-
-    lda = n
-    ldb = n
-
-    call sgetrs('N',n,1,a,lda,ipiv,b,ldb,info)
-
-    if (info /= 0) then
-      print *, "[dgetrs] info = ", info
+  subroutine handle_error(stat,istat,label)
+    integer, intent(out), optional :: stat
+    integer, intent(in) :: istat
+    character(len=*), intent(in) :: label
+    if (present(stat)) then
+      stat = istat
+    else if (istat /= 0) then
+      print '(a, *(1x, g0))', "["//label//"]", "info =", istat
+      stop 1
     end if
-
-  end subroutine
-  subroutine back_dp(n,ipiv,a,b)
-    integer, intent(in) :: n
-    integer, intent(in) :: ipiv(n)
-    real(dp), intent(in) :: a(n,n)
-    real(dp), intent(inout) :: b(n)
-
-    integer :: lda, ldb, info
-    external :: dgetrs
-
-    lda = n
-    ldb = n
-
-    call dgetrs('N',n,1,a,lda,ipiv,b,ldb,info)
-
-    if (info /= 0) then
-      print *, "[dgetrs] info = ", info
-    end if
-
-  end subroutine
+  end subroutine handle_error
 
 end module

--- a/src/stiff3_solver.f90
+++ b/src/stiff3_solver.f90
@@ -272,15 +272,15 @@ contains
     !
     ! perform triangular decomposition and evaluate k1
     !
-    call lu(n,ipiv,df)
-    call back(n,ipiv,df,f)
+    call lu(df,ipiv)
+    call back(df,f,ipiv)
 
     do i = 1, n
       yk1(i) = h*f(i)
       yk2(i) = y(i) + 0.75_wp * yk1(i)
     end do
     call fun(n,yk2,f)
-    call back(n,ipiv,df,f)
+    call back(df,f,ipiv)
 
     !
     ! evaluate k2
@@ -295,7 +295,7 @@ contains
     ! evaluate k3
     ! for convenience stored in yk2
     !
-    call back(n,ipiv,df,yk2)
+    call back(df,yk2,ipiv)
     do i = 1, n
       y(i) = y(i) + yk2(i)
     end do


### PR DESCRIPTION
- avoid argument mismatch error since RHS is a rank 2 array but passed as rank 1 to implicit interface
  (compilers like NAG can catch this even between different source files)
- instead use array bound remapping to create rank 2 view of RHS vector
- preserve order of arguments in Lapack wrappers